### PR TITLE
underscore.string now installs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "underscore.string": "~2.3.3"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.9.2",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.4",
-    "underscore.string": "~2.3.3"
+    "grunt": "~0.4.4"
   },
   "peerDependencies": {
     "grunt": "~0.4.4"


### PR DESCRIPTION
Fixes a problem where underscore.string was installing only as a devDependency, so `npm install grunt-texturepacker` did not include it by default.
